### PR TITLE
off by one in !players

### DIFF
--- a/Rodney.pm
+++ b/Rodney.pm
@@ -1166,7 +1166,8 @@ sub current_players {
     my $pretext;
 
     my $plrnames = join(', ', @players);
-    $pretext = "$#players player" . (($#players == 1) ? '' : 's') . ': ';
+    $pretext = scalar(@players) . " player" . 
+        ((scalar(@players) == 1) ? '' : 's') . ': ';
 
     if (@players) {
 	$plrnames = $pretext.$plrnames;


### PR DESCRIPTION
$#array isn't a count of elements in the array, it's the maximum array index; patch fixes number of players reported by !players.
